### PR TITLE
Implements Manifests and Platforms for Launchpad.

### DIFF
--- a/Launchpad.Launcher/Handlers/ChecksHandler.cs
+++ b/Launchpad.Launcher/Handlers/ChecksHandler.cs
@@ -213,15 +213,15 @@ namespace Launchpad.Launcher
 		/// Determines whether the  manifest is outdated.
 		/// </summary>
 		/// <returns><c>true</c> if the manifest is outdated; otherwise, <c>false</c>.</returns>
-		public bool IsManifestOutdated()
+		public bool IsManifestOutdated( string WhichManifest)
 		{
-			if (File.Exists(ConfigHandler.GetManifestPath()))
+			if (File.Exists(ConfigHandler.GetManifestPath( WhichManifest )))
 			{
 				FTPHandler FTP = new FTPHandler ();
 
-				string manifestURL = Config.GetManifestURL ();
+				string manifestURL = Config.GetManifestURL ( WhichManifest );
 				string remoteHash = FTP.ReadFTPFile (manifestURL);
-                string localHash = MD5Handler.GetFileHash(File.OpenRead(ConfigHandler.GetManifestPath()));
+                string localHash = MD5Handler.GetFileHash(File.OpenRead(ConfigHandler.GetManifestPath( WhichManifest )));
 
 				if (remoteHash != localHash)
 				{

--- a/Launchpad.Launcher/Handlers/ConfigHandler.cs
+++ b/Launchpad.Launcher/Handlers/ConfigHandler.cs
@@ -244,10 +244,10 @@ namespace Launchpad.Launcher
 		/// Gets the manifest's path on disk.
 		/// </summary>
 		/// <returns>The manifest path.</returns>
-        public static string GetManifestPath()
+        public static string GetManifestPath( string WhichManifest )
         {
-            string manifestPath = String.Format(@"{0}LauncherManifest.txt", 
-			                                    GetLocalDir());
+            string manifestPath = String.Format(@"{0}{1}Manifest.txt", 
+			                                    GetLocalDir(), WhichManifest);
             return manifestPath;
         }
 
@@ -255,10 +255,10 @@ namespace Launchpad.Launcher
 		/// Gets the old manifest's path on disk.
 		/// </summary>
 		/// <returns>The old manifest's path.</returns>
-		public static string GetOldManifestPath()
+		public static string GetOldManifestPath( string WhichManifest )
 		{
-			string oldManifestPath = String.Format(@"{0}LauncherManifest.txt.old", 
-			                                    GetLocalDir());
+			string oldManifestPath = String.Format(@"{0}{1}Manifest.txt.old", 
+			                                    GetLocalDir(), WhichManifest);
 			return oldManifestPath;
 		}
 
@@ -386,11 +386,13 @@ namespace Launchpad.Launcher
 		/// Gets the manifest URL.
 		/// </summary>
 		/// <returns>The manifest URL.</returns>
-        public string GetManifestURL()
+        public string GetManifestURL( string WhichManifest )
         {
-            string manifestURL = String.Format("{0}/game/{1}/LauncherManifest.txt", 
+            string manifestURL = String.Format("{0}/{1}/{2}/{3}Manifest.txt", 
                 GetFTPUrl(),
-                GetSystemTarget());
+                WhichManifest.ToLower(),
+                GetSystemTarget(),
+                WhichManifest);
 
             return manifestURL;
         }
@@ -399,11 +401,13 @@ namespace Launchpad.Launcher
 		/// Gets the manifest checksum URL.
 		/// </summary>
 		/// <returns>The manifest checksum URL.</returns>
-        public string GetManifestChecksumURL()
+        public string GetManifestChecksumURL( string WhichManifest )
         {
-            string manifestChecksumURL = String.Format("{0}/game/{1}/LauncherManifest.checksum", 
-                GetFTPUrl(), 
-                GetSystemTarget());
+            string manifestChecksumURL = String.Format("{0}/{1}/{2}/{3}Manifest.checksum",
+                GetFTPUrl(),
+                WhichManifest.ToLower(),
+                GetSystemTarget(),
+                WhichManifest);
 
             return manifestChecksumURL;
         }
@@ -414,8 +418,9 @@ namespace Launchpad.Launcher
 		/// <returns>The custom launcher download URL.</returns>
         public string GetLauncherBinariesURL()
         {
-            string launcherURL = String.Format("{0}/launcher/bin/", 
-			                                   GetFTPUrl());
+            string launcherURL = String.Format("{0}/launcher/{1}/bin/", 
+			                                   GetFTPUrl(),
+                                               GetSystemTarget());
             return launcherURL;
         }
 

--- a/Launchpad.Launcher/Handlers/FTPHandler.cs
+++ b/Launchpad.Launcher/Handlers/FTPHandler.cs
@@ -599,11 +599,11 @@ namespace Launchpad.Launcher
 			}
 		}
 
-		public string GetRemoteManifestChecksum()
+		public string GetRemoteManifestChecksum( string WhichManifest )
 		{
 			string checksum = String.Empty;
 
-			checksum = ReadFTPFile (Config.GetManifestChecksumURL ());
+			checksum = ReadFTPFile (Config.GetManifestChecksumURL ( WhichManifest ));
 			checksum = Utilities.Clean(checksum);
 
 			return checksum;

--- a/Launchpad.Launcher/Handlers/GameHandler.cs
+++ b/Launchpad.Launcher/Handlers/GameHandler.cs
@@ -134,7 +134,7 @@ namespace Launchpad.Launcher
 			try
 			{
 				FTPHandler FTP = new FTPHandler ();
-				ManifestHandler manifestHandler = new ManifestHandler ();
+				ManifestHandler manifestHandler = new ManifestHandler ( "Game" );
 				List<ManifestEntry> Manifest = manifestHandler.Manifest;
 
 				//create the .install file to mark that an installation has begun
@@ -262,7 +262,7 @@ namespace Launchpad.Launcher
 
 		private void UpdateGameAsync ()
 		{
-			ManifestHandler manifestHandler = new ManifestHandler ();
+			ManifestHandler manifestHandler = new ManifestHandler ( "Game" );
 
 			//check all local files against the manifest for file size changes.
 			//if the file is missing or the wrong size, download it.
@@ -332,18 +332,18 @@ namespace Launchpad.Launcher
 				FTP.FileProgressChanged += OnDownloadProgressChanged;
 
 				//first, verify that the manifest is correct.
-				string LocalManifestHash = MD5Handler.GetFileHash (File.OpenRead (ConfigHandler.GetManifestPath ()));
-				string RemoteManifestHash = FTP.GetRemoteManifestChecksum ();
+				string LocalManifestHash = MD5Handler.GetFileHash (File.OpenRead (ConfigHandler.GetManifestPath ( "Game" )));
+				string RemoteManifestHash = FTP.GetRemoteManifestChecksum ( "Game" );
 
 				//if it is not, download a new copy.
 				if (!(LocalManifestHash == RemoteManifestHash))
 				{
 					LauncherHandler Launcher = new LauncherHandler ();
-					Launcher.DownloadManifest ();
+					Launcher.DownloadManifest ("Game");
 				}
 
 				//then, begin repairing the game
-				ManifestHandler manifestHandler = new ManifestHandler ();
+				ManifestHandler manifestHandler = new ManifestHandler ( "Game" );
 				List<ManifestEntry> Manifest = manifestHandler.Manifest;			
 
 				ProgressArgs.TotalFiles = Manifest.Count;

--- a/Launchpad.Launcher/Handlers/LauncherHandler.cs
+++ b/Launchpad.Launcher/Handlers/LauncherHandler.cs
@@ -118,22 +118,22 @@ namespace Launchpad.Launcher
 		/// <summary>
 		/// Downloads the manifest.
 		/// </summary>
-		public void DownloadManifest()
+		public void DownloadManifest( string WhichManifest )
 		{
 			Stream manifestStream = null;														
 			try
 			{
 				FTPHandler FTP = new FTPHandler ();
 
-				string remoteChecksum = FTP.GetRemoteManifestChecksum ();
+				string remoteChecksum = FTP.GetRemoteManifestChecksum ( WhichManifest );
 				string localChecksum = "";
 
-				string RemoteURL = Config.GetManifestURL ();
-				string LocalPath = ConfigHandler.GetManifestPath ();
+				string RemoteURL = Config.GetManifestURL ( WhichManifest );
+				string LocalPath = ConfigHandler.GetManifestPath ( WhichManifest );
 
-				if (File.Exists(ConfigHandler.GetManifestPath()))
+				if (File.Exists(ConfigHandler.GetManifestPath( WhichManifest )))
 				{
-					manifestStream = File.OpenRead (ConfigHandler.GetManifestPath ());
+					manifestStream = File.OpenRead (ConfigHandler.GetManifestPath ( WhichManifest ));
                     localChecksum = MD5Handler.GetFileHash(manifestStream);
 
 					if (!(remoteChecksum == localChecksum))

--- a/Launchpad.Launcher/Handlers/LauncherHandler.cs
+++ b/Launchpad.Launcher/Handlers/LauncherHandler.cs
@@ -26,28 +26,47 @@ namespace Launchpad.Launcher
 	/// </summary>
 	internal sealed class LauncherHandler
 	{
-		/// <summary>
-		/// Occurs when changelog download progress changes.
-		/// </summary>
-		public event ChangelogProgressChangedEventHandler ChangelogProgressChanged;
-		/// <summary>
-		/// Occurs when changelog download finishes.
-		/// </summary>
-		public event ChangelogDownloadFinishedEventHandler ChangelogDownloadFinished;
+        /// <summary>
+        /// Occurs when progress changed.
+        /// </summary>
+        public event GameProgressChangedEventHandler ProgressChanged;
+        /// <summary>
+        /// Occurs when game update finished.
+        /// </summary>
+        public event GameUpdateFinishedEventHandler GameUpdateFinished;
+        /// <summary>
+        /// Occurs when game update failed.
+        /// </summary>
+        public event GameUpdateFailedEventHandler GameUpdateFailed;
+        /// <summary>
+        /// The update failed arguments.
+        /// </summary>
+        private GameUpdateFailedEventArgs UpdateFailedArgs;
+        /// <summary>
+        /// Occurs when changelog download progress changes.
+        /// </summary>
+        public event ChangelogProgressChangedEventHandler ChangelogProgressChanged;
+        /// <summary>
+        /// Occurs when changelog download finishes.
+        /// </summary>
+        public event ChangelogDownloadFinishedEventHandler ChangelogDownloadFinished;
+        /// <summary>
+        /// The update finished arguments.
+        /// </summary>
+        private GameUpdateFinishedEventArgs UpdateFinishedArgs;
+        /// <summary>
+        /// The progress arguments object. Is updated during file download operations.
+        /// </summary>
+        private FileDownloadProgressChangedEventArgs ProgressArgs;
+        /// <summary>
+        /// The download finished arguments object. Is updated once a file download finishes.
+        /// </summary>
+        private GameDownloadFinishedEventArgs DownloadFinishedArgs;
 
-		/// <summary>
-		/// The progress arguments object. Is updated during file download operations.
-		/// </summary>
-		private FileDownloadProgressChangedEventArgs ProgressArgs;
-		/// <summary>
-		/// The download finished arguments object. Is updated once a file download finishes.
-		/// </summary>
-		private GameDownloadFinishedEventArgs DownloadFinishedArgs;
-
-		/// <summary>
-		/// The config handler reference.
-		/// </summary>
-		ConfigHandler Config = ConfigHandler._instance;
+        /// <summary>
+        /// The config handler reference.
+        /// </summary>
+        ConfigHandler Config = ConfigHandler._instance;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Launchpad_Launcher.LauncherHandler"/> class.
@@ -58,67 +77,121 @@ namespace Launchpad.Launcher
 			DownloadFinishedArgs = new GameDownloadFinishedEventArgs ();
 		}
 
-		//TODO: Update this function to handle DLLs as well. May have to implement a full-blown
-		//manifest system here as well.
+        //TODO: Update this function to handle DLLs as well. May have to implement a full-blown
+        //manifest system here as well.
 
-		/// <summary>
-		/// Updates the launcher synchronously.
-		/// </summary>
-		public void UpdateLauncher()
-		{
-			try
-			{
-				FTPHandler FTP = new FTPHandler ();
+        /// <summary>
+        /// Starts an asynchronous game update task.
+        /// </summary>
+        public void UpdateLauncher()
+        {
+            Thread t = new Thread(UpdateLauncherAsync);
+            t.Start();
+        }
 
-                //crawl the server for all of the files in the /launcher/bin directory.
-                List<string> remotePaths = FTP.GetFilePaths(Config.GetLauncherBinariesURL(), true);
 
-                //download all of them
-                foreach (string path in remotePaths)
+        private void OnGameUpdateFinished()
+        {
+            if (GameUpdateFinished != null)
+            {
+                GameUpdateFinished(this, UpdateFinishedArgs);
+            }
+        }
+
+        private void OnGameUpdateFailed()
+        {
+            if (GameUpdateFailed != null)
+            {
+                GameUpdateFailed(this, UpdateFailedArgs);
+            }
+        }
+
+        /// <summary>
+        /// Raises the download progress changed event.
+        /// </summary>
+        /// <param name="sender">Sender.</param>
+        /// <param name="e">E.</param>
+        private void OnDownloadProgressChanged(object sender, FileDownloadProgressChangedEventArgs e)
+        {
+            ProgressArgs = e;
+            OnProgressChanged();
+        }
+
+        private void OnFileDownloadFinished(object sender, FileDownloadFinishedEventArgs e)
+        {
+            OnProgressChanged();
+        }
+
+        /// <summary>
+        /// Raises the progress changed event.
+        /// </summary>
+        private void OnProgressChanged()
+        {
+            if (ProgressChanged != null)
+            {
+                ProgressChanged(this, ProgressArgs);
+            }
+        }
+
+
+        private void UpdateLauncherAsync()
+        {
+            ManifestHandler manifestHandler = new ManifestHandler("Launcher");
+
+            //check all local files against the manifest for file size changes.
+            //if the file is missing or the wrong size, download it.
+            //better system - compare old & new manifests for changes and download those?
+            List<ManifestEntry> Manifest = manifestHandler.Manifest;
+            List<ManifestEntry> OldManifest = manifestHandler.OldManifest;
+
+            try
+            {
+                //Check old manifest against new manifest, download anything that isn't exactly the same as before
+                FTPHandler FTP = new FTPHandler();
+                FTP.FileProgressChanged += OnDownloadProgressChanged;
+                FTP.FileDownloadFinished += OnFileDownloadFinished;
+
+                foreach (ManifestEntry Entry in Manifest)
                 {
-                    try
+                    if (!OldManifest.Contains(Entry))
                     {
-                        if (!String.IsNullOrEmpty(path))
-                        {
-                            string Local = String.Format("{0}launchpad{1}{2}",
-                                             ConfigHandler.GetTempDir(),
-                                             Path.DirectorySeparatorChar,
-                                             path);
+                        string RemotePath = String.Format("{0}{1}",
+                                                                  Config.GetLauncherBinariesURL(),
+                                                                  Entry.RelativePath);
 
-                            string Remote = String.Format("{0}{1}",
-                                                Config.GetLauncherBinariesURL(),
-                                                path);
+                        string LocalPath = String.Format("{0}\\launchpad\\{1}",
+                                               ConfigHandler.GetTempDir(),
+                                               Entry.RelativePath);
 
-                            if (!Directory.Exists(Local))
-                            {
-                                Directory.CreateDirectory(Directory.GetParent(Local).ToString());
-                            }
+                        Directory.CreateDirectory(Directory.GetParent(LocalPath).ToString());
 
-                            FTP.DownloadFTPFile(Remote, Local, false);
-                        }                        
-                    }
-                    catch (WebException wex)
-                    {
-                        Console.WriteLine("WebException in UpdateLauncher(): " + wex.Message);
+                        OnProgressChanged();
+                        FTP.DownloadFTPFile(RemotePath, LocalPath, false);
                     }
                 }
-				
-                //TODO: Make the script copy recursively
-				ProcessStartInfo script = CreateUpdateScript ();
 
-				Process.Start(script);
-				Environment.Exit(0);
-			}
-			catch (IOException ioex)
-			{
-				Console.WriteLine ("IOException in UpdateLauncher(): " + ioex.Message);
-			}
-		}
+                OnGameUpdateFinished();
+                ProcessStartInfo script = CreateUpdateScript();
 
-		/// <summary>
-		/// Downloads the manifest.
-		/// </summary>
-		public void DownloadManifest( string WhichManifest )
+                Process.Start(script);
+                Environment.Exit(0);
+
+                //clear out the event handlers
+                FTP.FileProgressChanged -= OnDownloadProgressChanged;
+                FTP.FileDownloadFinished -= OnFileDownloadFinished;
+            }
+            catch (IOException ioex)
+            {
+                Console.WriteLine("IOException in UpdateGameAsync(): " + ioex.Message);
+                OnGameUpdateFailed();
+            }
+        }
+
+
+        /// <summary>
+        /// Downloads the manifest.
+        /// </summary>
+        public void DownloadManifest( string WhichManifest )
 		{
 			Stream manifestStream = null;														
 			try

--- a/Launchpad.Launcher/Handlers/ManifestHandler.cs
+++ b/Launchpad.Launcher/Handlers/ManifestHandler.cs
@@ -6,6 +6,7 @@ namespace Launchpad.Launcher
 {
 	internal sealed class ManifestHandler
 	{
+        private string WhichManifest;
 		private List<ManifestEntry> manifest = new List<ManifestEntry> ();
 
 		/// <summary>
@@ -17,7 +18,7 @@ namespace Launchpad.Launcher
 		{
 			get
 			{
-				LoadManifest ();
+				LoadManifest ( WhichManifest );
 				return manifest;
 			}
 		}
@@ -33,7 +34,7 @@ namespace Launchpad.Launcher
 		{
 			get
 			{
-				LoadOldManifest ();
+				LoadOldManifest ( WhichManifest );
 				return oldManifest;
 			}
 		}
@@ -41,23 +42,23 @@ namespace Launchpad.Launcher
 		private object ManifestLock = new object ();
 		private object OldManifestLock = new object ();
 
-		public ManifestHandler ()
+		public ManifestHandler ( string ManifestName )
 		{
-
+            WhichManifest = ManifestName;
 		}
 
 		/// <summary>
 		/// Loads the manifest from disk.
 		/// </summary>
-		private void LoadManifest ()
+		private void LoadManifest ( string WhichManifest )
 		{
 			try
 			{
 				lock (ManifestLock)
 				{
-					if (File.Exists (ConfigHandler.GetManifestPath ()))
+					if (File.Exists (ConfigHandler.GetManifestPath ( WhichManifest )))
 					{
-						string[] rawManifest = File.ReadAllLines (ConfigHandler.GetManifestPath ());
+						string[] rawManifest = File.ReadAllLines (ConfigHandler.GetManifestPath ( WhichManifest ));
 						foreach (string rawEntry in rawManifest)
 						{
 							ManifestEntry newEntry = new ManifestEntry ();
@@ -78,15 +79,15 @@ namespace Launchpad.Launcher
 		/// <summary>
 		/// Loads the old manifest from disk.
 		/// </summary>
-		private void LoadOldManifest ()
+		private void LoadOldManifest ( string WhichManifest )
 		{
 			try
 			{
 				lock (OldManifestLock)
 				{
-					if (File.Exists (ConfigHandler.GetOldManifestPath ()))
+					if (File.Exists (ConfigHandler.GetOldManifestPath ( WhichManifest )))
 					{
-						string[] rawOldManifest = File.ReadAllLines (ConfigHandler.GetOldManifestPath ());
+						string[] rawOldManifest = File.ReadAllLines (ConfigHandler.GetOldManifestPath ( WhichManifest ));
 						foreach (string rawEntry in rawOldManifest)
 						{
 							ManifestEntry newEntry = new ManifestEntry ();

--- a/Launchpad.Launcher/Unix-UI/MainWindow.cs
+++ b/Launchpad.Launcher/Unix-UI/MainWindow.cs
@@ -135,9 +135,9 @@ namespace Launchpad.Launcher
 				//if the launcher does not need an update at this point, we can continue checks for the game
 				if (!Checks.IsLauncherOutdated ())
 				{
-					if (Checks.IsManifestOutdated ())
+					if (Checks.IsManifestOutdated ( "Launcher" ))
 					{					
-						Launcher.DownloadManifest ();
+						Launcher.DownloadManifest ( "Launcher" );
 					}
 
 					if (!Checks.IsGameInstalled ())

--- a/Launchpad.Launcher/Windows-UI/MainForm.cs
+++ b/Launchpad.Launcher/Windows-UI/MainForm.cs
@@ -125,9 +125,9 @@ namespace Launchpad.Launcher
                 //Does the launcher need an update?
                 if (!Checks.IsLauncherOutdated())
                 {
-                    if (Checks.IsManifestOutdated())
+                    if (Checks.IsManifestOutdated( "Game" ))
                     {
-                        Launcher.DownloadManifest();
+                        Launcher.DownloadManifest("Game" );
                     }
 
                     if(!Checks.IsGameInstalled())

--- a/Launchpad.Utilities/Handlers/ManifestHandler.cs
+++ b/Launchpad.Utilities/Handlers/ManifestHandler.cs
@@ -54,35 +54,39 @@ namespace Launchpad.Utilities
 			{
 				if (file != null)
 				{
-					FileStream fileStream = File.OpenRead (file);
-					var skipDirectory = TargetPath;
+                    // Skip debugging files during test cycles.
+                    if (!file.EndsWith(".pdb"))
+                    {
+                        FileStream fileStream = File.OpenRead(file);
+                        var skipDirectory = TargetPath;
 
-					int fileAmount = files.Length; 
-					string currentFile = file.Substring (skipDirectory.Length);
+                        int fileAmount = files.Length;
+                        string currentFile = file.Substring(skipDirectory.Length);
 
-					//get file size on disk
-					FileInfo Info = new FileInfo (file);
-					long fileSize = Info.Length;
+                        //get file size on disk
+                        FileInfo Info = new FileInfo(file);
+                        long fileSize = Info.Length;
 
-					string hash = MD5Handler.GetFileHash (fileStream);
-					string manifestLine = String.Format (@"{0}:{1}:{2}", file.Substring (skipDirectory.Length), hash, fileSize.ToString ());
+                        string hash = MD5Handler.GetFileHash(fileStream);
+                        string manifestLine = String.Format(@"{0}:{1}:{2}", file.Substring(skipDirectory.Length), hash, fileSize.ToString());
 
-					if (fileStream != null)
-					{
-						fileStream.Close ();	
-					}
+                        if (fileStream != null)
+                        {
+                            fileStream.Close();
+                        }
 
-					completedFiles++;
+                        completedFiles++;
 
 
-					tw.WriteLine (manifestLine);
-					ProgressArgs.Filepath = currentFile;
-					ProgressArgs.TotalFiles = fileAmount;
-					ProgressArgs.CompletedFiles = completedFiles;
-					ProgressArgs.MD5 = hash;
-					ProgressArgs.Filesize = fileSize;
+                        tw.WriteLine(manifestLine);
+                        ProgressArgs.Filepath = currentFile;
+                        ProgressArgs.TotalFiles = fileAmount;
+                        ProgressArgs.CompletedFiles = completedFiles;
+                        ProgressArgs.MD5 = hash;
+                        ProgressArgs.Filesize = fileSize;
 
-					OnManifestGenerationProgressChanged ();
+                        OnManifestGenerationProgressChanged();
+                    }
 				}
 			}
 			tw.Close ();

--- a/Launchpad.Utilities/Windows-UI/MainForm.cs
+++ b/Launchpad.Utilities/Windows-UI/MainForm.cs
@@ -125,21 +125,23 @@ namespace Launchpad.Utilities
 						int fileAmount = files.Length; 
 						string currentFile = file.Substring (skipDirectory.Length);
 
-						//get file size on disk
-						FileInfo Info = new FileInfo (file);
-						string fileSize = Info.Length.ToString ();
-                        
-						string manifestLine = String.Format (@"{0}:{1}:{2}", file.Substring (skipDirectory.Length), MD5Handler.GetFileHash (fileStream), fileSize);
+                        // Skip Debugging files. Breaks when testing if permitted.
 
-						if (fileStream != null)
-						{
-							fileStream.Close ();	
-						}
-							
-						completedFiles++;
-                        
+                        if (!file.EndsWith(".pdb"))
+                        {
+                            //get file size on disk
+                            FileInfo Info = new FileInfo(file);
+                            string fileSize = Info.Length.ToString();
 
-						tw.WriteLine (manifestLine);
+                            string manifestLine = String.Format(@"{0}:{1}:{2}", file.Substring(skipDirectory.Length), MD5Handler.GetFileHash(fileStream), fileSize);
+
+                            if (fileStream != null)
+                            {
+                                fileStream.Close();
+                            }
+                            tw.WriteLine(manifestLine);
+                        }
+                        completedFiles++;
 						backgroundWorker_manifestGenerator.ReportProgress (completedFiles, new Tuple<int, int, string> (fileAmount, completedFiles, currentFile));
 					}
 				}


### PR DESCRIPTION
Behavior changes:

Expects to use LauncherManifest.txt and LauncherManifest.checksum for Program Launcher.
Expects to use GameManifest.txt and GameManifest.checksum for the game.

Expects the /launcher/ to mirror game file structure on update server:
e.g. The files for the Win64 launcher would be placed in
<root>/launcher/Win64/bin