### PR TITLE
Return a fully formed manifest URL

### DIFF
--- a/Launchpad.Common/Handlers/Manifest/ManifestHandler.cs
+++ b/Launchpad.Common/Handlers/Manifest/ManifestHandler.cs
@@ -213,10 +213,10 @@ namespace Launchpad.Common.Handlers.Manifest
 		{
 			if (manifestType == EManifestType.Launchpad)
 			{
-				return $"{this.RemoteURL.LocalPath}/launcher/{manifestType}Manifest.txt";
+				return $"{this.RemoteURL}/launcher/{manifestType}Manifest.txt";
 			}
 
-			return $"{this.RemoteURL.LocalPath}/game/{this.SystemTarget}/{manifestType}Manifest.txt";
+			return $"{this.RemoteURL}/game/{this.SystemTarget}/{manifestType}Manifest.txt";
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes an issue where the local portion of the base URL was duplicated when trying to download manifests.
