### PR TITLE
A simple setup for vagrant

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -1,0 +1,7 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.network "private_network", ip: "192.168.75.75"
+  end


### PR DESCRIPTION
If someone wants to do local development, they can use this vagrantfile.   And then they will be able to put the address IP ftp://192.168.75.75 in LauncherConfig.ini and go on with the testing.